### PR TITLE
Avoid short array syntax.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -790,11 +790,11 @@ function wbz404_adminHeader( $sub = 'list', $message = '' ) {
 	}
 	echo "<h2>" . __( '404 Redirected', '404-redirected' ) . esc_html( $header ) . "</h2>";
 	if ( $message != "" ) {
-		$allowed_tags = [
-			'br'     => [],
-			'em'     => [],
-			'strong' => [],
-		];
+		$allowed_tags = array(
+			'br'     => array(),
+			'em'     => array(),
+			'strong' => array(),
+		);
 		echo "<div class=\"message updated\"><p>" . wp_kses( $message, $allowed_tags ) . "</p></div>";
 	}
 	echo __( 'by', '404-redirected' ) . " <a href=\"https://redirectioner.com\" title=\"Redirectioner\" target=\"_blank\">Redirectioner</a><br>";


### PR DESCRIPTION
Short array syntax was only introduced in PHP 5.4 and causes a parse error for lower versions (we officially still support 5.2+).

Fixes #30